### PR TITLE
Add a plugin for Syntastic.

### DIFF
--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -1,0 +1,40 @@
+"============================================================================
+"File:        rust.vim
+"Description: Syntax checking plugin for syntastic.vim
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists("g:loaded_syntastic_rust_rustc_checker")
+    finish
+endif
+let g:loaded_syntastic_rust_rustc_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_rust_rustc_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args': '--parse-only' })
+
+    let errorformat  =
+        \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
+        \ '%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m,' .
+        \ '%C%f:%l %m,' .
+        \ '%-Z%.%#'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'rust',
+    \ 'name': 'rustc'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:


### PR DESCRIPTION
It's pretty bare bones support. It basically just checks if the syntax of a Rust file is correct.

There is a more useful `--no-trans` option that can be given to `rustc`, but it doesn't work well as a default since it needs to be given the crate root file (otherwise it will generate false errors). This behavior can be achieved by overriding some options in your `.vimrc` (in my case, I put them in my project specific `.vim` file):

``` vimscript
let g:syntastic_rust_rustc_fname = "src/lib.rs"
let g:syntastic_rust_rustc_args = "--no-trans"
```
