### PR TITLE
Add Cargo compiler.

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -21,13 +21,11 @@ au QuickfixCmdPost make call s:FixRelativePaths()
 " to be relative to the current directory instead of Cargo.toml.
 function! s:FixRelativePaths()
     let qflist = getqflist()
-    let has_errors = 0
     let toml = FindCargoToml()
     for qf in qflist
         if !qf['valid']
             continue
         endif
-        let has_errors = 1
         let filename = bufname(qf['bufnr'])
         if stridx(filename, toml) == -1
             let filename = toml.filename


### PR DESCRIPTION
This PR adds a new compiler specifically targeting Cargo. Cargo automatically searches upwards for a Cargo.toml, but if an error is encountered, then the path of that error will be relative to Cargo.toml and not vim's working directory, which means that trying to jump to the file via quickfix brings you to an empty buffer. This compiler sets up an autocommand to automatically fix the file paths and make the quickfix window work as expected.

One possible improvement for this is to get it to properly jump to the first error, which I couldn't get it to do, but I think it's functional enough to warrant inclusion.
