### PR TITLE
added .gitignore for doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
If you're using rust.vim as a git submodule and you generate the help tags file (vim-plug does this automatically) you get annoying untracked content messages. This should fix it.
