### PR TITLE
Ignore '/doc/tags'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Most vim plugins ignore `/doc/tags` since it's a generated file
###### References
- https://github.com/gmarik/Vundle.vim/blob/master/.gitignore
- https://github.com/sjl/gundo.vim/blob/master/.gitignore
- https://github.com/scrooloose/nerdtree/blob/master/.gitignore
- https://github.com/godlygeek/tabular/blob/master/.gitignore
- _et cetera_
