### PR TITLE
Fix typo from /docs/tag to /doc/tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/docs/tags
+/doc/tags


### PR DESCRIPTION
Quick fix for typo